### PR TITLE
Adds notes for Ubuntu system shortcut

### DIFF
--- a/workshop/02_Editing/04_Surround_With/4.1_Surround_with.php
+++ b/workshop/02_Editing/04_Surround_With/4.1_Surround_with.php
@@ -10,7 +10,9 @@
  * Alt+Enter (Windows/Linux/Mac OSX)
  *
  * Wrap the selected text with relevant content (e.g. try/catch or if statement)
+ *
  * NOTE: You can also invoke contextual surrounds using Show Intention Actions
+ * NOTE: On Ubuntu, Ctrl+Alt+T is overwritten by a system shortcut - you may need to rebind these keys to use the shortcuts.
  */
 
 namespace Editing4\JetBrains;

--- a/workshop/04_Live_Templates/03_Surround_Templates/3.1_Simple_template.php
+++ b/workshop/04_Live_Templates/03_Surround_Templates/3.1_Simple_template.php
@@ -13,6 +13,8 @@
  * Alt+Command+J (macOS)
  *
  * Surround code with a template. A template is only seen as a surround template when the $SELECTION$ variable is defined.
+ *
+ * NOTE: On Ubuntu, Ctrl+Alt+T is overwritten by a system shortcut - you may need to rebind these keys to use the shortcuts.
  */
 
 namespace LiveTemplates3\JetBrains;


### PR DESCRIPTION
This PR adds information for Ubuntu users. 
On Ubuntu, `Ctrl+Alt+T` is used as a system shortcut for `Open Terminal`